### PR TITLE
avoid sub-classing ThreadLocal since it will leak in envs such as .wars

### DIFF
--- a/src/org/joni/StackMachine.java
+++ b/src/org/joni/StackMachine.java
@@ -66,19 +66,19 @@ abstract class StackMachine extends Matcher implements StackType {
     }
 
     static final ThreadLocal<WeakReference<StackEntry[]>> stacks
-            = new ThreadLocal<WeakReference<StackEntry[]>>() {
-        @Override
-        protected WeakReference<StackEntry[]> initialValue() {
-            return new WeakReference<StackEntry[]>(allocateStack());
-        }
-    };
+            = new ThreadLocal<WeakReference<StackEntry[]>>();
 
     private static StackEntry[] fetchStack() {
         WeakReference<StackEntry[]> ref = stacks.get();
-        StackEntry[] stack = ref.get();
-        if (stack == null) {
-            ref = new WeakReference<StackEntry[]>(stack = allocateStack());
-            stacks.set(ref);
+        StackEntry[] stack;
+        if (ref == null) {
+            stacks.set( new WeakReference<StackEntry[]>(stack = allocateStack()) );
+        }
+        else {
+            stack = ref.get();
+            if (stack == null) {
+                stacks.set( new WeakReference<StackEntry[]>(stack = allocateStack()) );
+            }
         }
         return stack;
     }


### PR DESCRIPTION
e.g. on Tomcat a Warbled up with this change (tested 1.7.13) allows to avoid the following warning : 

```
Jun 27, 2014 4:00:45 PM org.apache.catalina.loader.WebappClassLoader checkThreadLocalMapForLeaks
SEVERE: The web application [/hellowarld] created a ThreadLocal with key of type [org.joni.StackMachine$1] (value [org.joni.StackMachine$1@763c3222]) and a value of type [java.lang.ref.WeakReference] (value [java.lang.ref.WeakReference@69ff92d2]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
```

... and correctly release memory

this issue is related to https://github.com/jruby/jruby/pull/1772
