### PR TITLE
Fix quantifier and non-capturing group interaction under JavaScript

### DIFF
--- a/src/org/joni/Parser.java
+++ b/src/org/joni/Parser.java
@@ -890,7 +890,7 @@ class Parser extends Lexer {
         while (token.type == TokenType.OP_REPEAT || token.type == TokenType.INTERVAL) { // repeat:
             if (target.isInvalidQuantifier()) newSyntaxException(ERR_TARGET_OF_REPEAT_OPERATOR_INVALID);
 
-            if (syntax.op2OptionECMAScript() && target.getType() == NodeType.QTFR) {
+            if (!group && syntax.op2OptionECMAScript() && target.getType() == NodeType.QTFR) {
                 newSyntaxException(ERR_NESTED_REPEAT_NOT_ALLOWED);
             }
             QuantifierNode qtfr = new QuantifierNode(token.getRepeatLower(),


### PR DESCRIPTION
Multiple quantifiers for the same token are not allowed in
JavaScript. However, our check was too broad for this before and it
was throwing an error when a non-capturing group ended in a repeat and
there was a repeat immediately following the non-capturing group.

This fixes that behavior by respecting the boolean group flag to know
whether we're dealing with a non-capturing group or not.
