### PR TITLE
Check the validity of all mbc created

### DIFF
--- a/src/org/joni/OptMapInfo.java
+++ b/src/org/joni/OptMapInfo.java
@@ -21,6 +21,8 @@ package org.joni;
 
 import org.jcodings.CaseFoldCodeItem;
 import org.jcodings.Encoding;
+import org.joni.exception.ErrorMessages;
+import org.joni.exception.ValueException;
 
 final class OptMapInfo {
 
@@ -61,7 +63,10 @@ final class OptMapInfo {
 
         byte[] buf = new byte[Config.ENC_CODE_TO_MBC_MAXLEN];
         for (int i=0; i<items.length; i++) {
-            enc.codeToMbc(items[i].code[0], buf, 0);
+            int len = enc.codeToMbc(items[i].code[0], buf, 0);
+            if (enc.length(buf, 0, len) < 0) {
+                throw new ValueException(ErrorMessages.ERR_INVALID_UNICODE);
+            }
             addChar(buf[0], enc);
         }
     }

--- a/src/org/joni/Parser.java
+++ b/src/org/joni/Parser.java
@@ -741,6 +741,9 @@ class Parser extends Lexer {
         case CODE_POINT:
             byte[]buf = new byte[Config.ENC_CODE_TO_MBC_MAXLEN];
             int num = enc.codeToMbc(token.getCode(), buf, 0);
+            if (enc.length(buf, 0, num) < 0) {
+                newValueException(ERR_INVALID_UNICODE);
+            }
             // #ifdef NUMBERED_CHAR_IS_NOT_CASE_AMBIG ... // setRaw() #else
             node = new StringNode(buf, 0, num);
             break;

--- a/src/org/joni/ast/StringNode.java
+++ b/src/org/joni/ast/StringNode.java
@@ -22,6 +22,8 @@ package org.joni.ast;
 import org.jcodings.Encoding;
 import org.joni.Config;
 import org.joni.constants.StringType;
+import org.joni.exception.ErrorMessages;
+import org.joni.exception.ValueException;
 
 public final class StringNode extends Node implements StringType {
 
@@ -154,7 +156,11 @@ public final class StringNode extends Node implements StringType {
 
     public void catCode(int code, Encoding enc) {
         ensure(Config.ENC_CODE_TO_MBC_MAXLEN);
+        int oldEnd = end;
         end += enc.codeToMbc(code, bytes, end);
+        if (enc.length(bytes, oldEnd, end) < 0) {
+            throw new ValueException(ErrorMessages.ERR_INVALID_UNICODE);
+        }
     }
 
     public void clear() {

--- a/src/org/joni/exception/ErrorMessages.java
+++ b/src/org/joni/exception/ErrorMessages.java
@@ -90,5 +90,6 @@ public interface ErrorMessages extends org.jcodings.exception.ErrorMessages {
     final String ERR_INVALID_COMBINATION_OF_OPTIONS = "invalid combination of options";
     final String ERR_OVER_THREAD_PASS_LIMIT_COUNT = "over thread pass limit count";
     final String ERR_TOO_BIG_SB_CHAR_VALUE = "too big singlebyte char value";
+    final String ERR_INVALID_UNICODE = "invalid unicode";
 
 }


### PR DESCRIPTION
Related to #17. Fixes the infinite loops.
- Before fix, `A\uD800` causes infinite loop. Now, it will fail loudly, as expected.
- Before fix, `\uD800\uDC00` causes infinite loop. Now, it will fail loudly. The expected result is consider it equivalent to `\x{10000}`. But that requires much more changes to joni.
