### PR TITLE
make joni reproducible build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,11 +20,6 @@
     <target name="build" depends="compile">
         <mkdir dir="${dist.dir}" />
 
-        <tstamp>
-            <format property="buildDate" pattern="yyyy-MM-dd" />
-            <format property="buildTime" pattern="HH:mm:ss" />
-        </tstamp>
-
         <jar destfile="${dist.dir}/${jar.name}" manifest="MANIFEST.MF">
             <fileset dir="${bin.dir}" />
 


### PR DESCRIPTION
As a part of effort for reproducible build, remove build timestamp.
For more detail about it, see https://reproducible-builds.org/