### PR TITLE
Downgrade the maven-surefire-plugin to a version which tolerates Alpine Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.19.1</version>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/SUREFIRE-1422

Once 2.21.0 comes out, this should be re-tested