### PR TITLE
Fix out-of-bounds reads when parsing \p{ and other regular expressions

### DIFF
--- a/src/org/joni/Lexer.java
+++ b/src/org/joni/Lexer.java
@@ -111,6 +111,7 @@ class Lexer extends ScannerSupport {
 
         if (syntax.opEscBraceInterval()) {
             if (c != syntax.metaCharTable.esc) return invalidRangeQuantifier(synAllow);
+            if (!left()) return invalidRangeQuantifier(synAllow);
             fetch();
         }
 
@@ -272,6 +273,7 @@ class Lexer extends ScannerSupport {
             if (c == '+' || c == '-') {
                 int flag = c == '-' ? -1 : 1;
 
+                if (!left()) newValueException(INVALID_CHAR_IN_GROUP_NAME);
                 fetch();
                 if (!enc.isDigit(c)) newValueException(INVALID_GROUP_NAME, src, stop);
                 unfetch();
@@ -280,8 +282,10 @@ class Lexer extends ScannerSupport {
                 rlevel.p = level * flag;
                 existLevel = true;
 
-                fetch();
-                isEndCode = c == endCode;
+                if (left()) {
+                    fetch();
+                    isEndCode = c == endCode;
+                }
             }
 
             if (!isEndCode) {
@@ -526,13 +530,15 @@ class Lexer extends ScannerSupport {
     }
 
     private void fetchTokenInCCFor_p() {
+        if (!left()) return;
+
         int c2 = peek(); // !!! migrate to peekIs
         if (c2 == '{' && syntax.op2EscPBraceCharProperty()) {
             inc();
             token.type = TokenType.CHAR_PROPERTY;
             token.setPropNot(c == 'P');
 
-            if (syntax.op2EscPBraceCircumflexNot()) {
+            if (left() && syntax.op2EscPBraceCircumflexNot()) {
                 c2 = fetchTo();
                 if (c2 == '^') {
                     token.setPropNot(!token.getPropNot());
@@ -979,7 +985,7 @@ class Lexer extends ScannerSupport {
             token.type = TokenType.CHAR_PROPERTY;
             token.setPropNot(c == 'P');
 
-            if (syntax.op2EscPBraceCircumflexNot()) {
+            if (left() && syntax.op2EscPBraceCircumflexNot()) {
                 fetch();
                 if (c == '^') {
                     token.setPropNot(!token.getPropNot());

--- a/src/org/joni/Lexer.java
+++ b/src/org/joni/Lexer.java
@@ -1315,7 +1315,7 @@ class Lexer extends ScannerSupport {
                 throw new CharacterPropertyException(EncodingError.ERR_INVALID_CHAR_PROPERTY_NAME, bytes, _p, last);
             }
         }
-        newInternalException(PARSER_BUG);
+        newValueException(PROPERTY_NAME_NEVER_TERMINATED, _p, stop);
         return 0; // not reached
     }
 

--- a/src/org/joni/Parser.java
+++ b/src/org/joni/Parser.java
@@ -469,6 +469,7 @@ class Parser extends Lexer {
                 } // USE_NAMED_GROUP
                 break;
             case '<':  /* look behind (?<=...), (?<!...) */
+                if (!left()) newSyntaxException(END_PATTERN_WITH_UNMATCHED_PARENTHESIS);
                 fetch();
                 if (c == '=') {
                     node = new AnchorNode(AnchorType.LOOK_BEHIND);
@@ -495,7 +496,7 @@ class Parser extends Lexer {
             case '@':
                 if (syntax.op2AtMarkCaptureHistory()) {
                     if (Config.USE_NAMED_GROUP) {
-                        if (syntax.op2QMarkLtNamedGroup()) {
+                        if (left() && syntax.op2QMarkLtNamedGroup()) {
                             fetch();
                             if (c == '<' || c == '\'') {
                                 listCapture = true;
@@ -515,7 +516,7 @@ class Parser extends Lexer {
                 break;
 
             case '(':   /* conditional expression: (?(cond)yes), (?(cond)yes|no) */
-                if (syntax.op2QMarkLParenCondition()) {
+                if (left() && syntax.op2QMarkLParenCondition()) {
                     int num = -1;
                     int name = -1;
                     fetch();

--- a/src/org/joni/exception/ErrorMessages.java
+++ b/src/org/joni/exception/ErrorMessages.java
@@ -77,6 +77,7 @@ public interface ErrorMessages extends org.jcodings.exception.ErrorMessages {
     final String UNDEFINED_GROUP_REFERENCE = "undefined group <%n> reference";
     final String MULTIPLEX_DEFINED_NAME = "multiplex defined name <%n>";
     final String MULTIPLEX_DEFINITION_NAME_CALL = "multiplex definition name <%n> call";
+    final String PROPERTY_NAME_NEVER_TERMINATED = "property name never terminated \\p{%n";
     final String NEVER_ENDING_RECURSION = "never ending recursion";
     final String GROUP_NUMBER_OVER_FOR_CAPTURE_HISTORY = "group number is too big for capture history";
     final String NOT_SUPPORTED_ENCODING_COMBINATION = "not supported encoding combination";


### PR DESCRIPTION
Parsing a regular expression such as `\p{` throws an `ArrayIndexOutOfBoundsException` with an index as a message instead of throwing something more informative. This is due to the fact that the parser is missing some end-of-string checks before some `fetch` calls. This was an issue with `oniguruma` and `Onigmo` too, but it was fixed in 2016.

https://github.com/k-takata/Onigmo/commit/29e7e6aedebafd5efbbd90655c8e0d495035d7b4

In the first commit, I have ported the changeset linked above to Joni.

Continuing with my regular expression, `\p{` now throws an exception with the internal `PARSER_BUG` message. The second commit fixes this by reporting a more friendly error message.

By the way, the example regular expression is currently broken in MRI Ruby. The parser bug is there too, but instead of throwing an exception, it starts having nonsense semantics. In this particular case, `\p{` will match a newline character.

```
irb(main):001:0> /\p{/.match("\n")
=> #<MatchData "\n">
``` 