### PR TITLE
Remove unsound quantifier reduction rules.

### DIFF
--- a/src/org/joni/ast/QuantifierNode.java
+++ b/src/org/joni/ast/QuantifierNode.java
@@ -23,7 +23,6 @@ import static org.joni.ast.QuantifierNode.ReduceType.A;
 import static org.joni.ast.QuantifierNode.ReduceType.AQ;
 import static org.joni.ast.QuantifierNode.ReduceType.ASIS;
 import static org.joni.ast.QuantifierNode.ReduceType.DEL;
-import static org.joni.ast.QuantifierNode.ReduceType.PQ_Q;
 import static org.joni.ast.QuantifierNode.ReduceType.P_QQ;
 import static org.joni.ast.QuantifierNode.ReduceType.QQ;
 
@@ -137,7 +136,6 @@ public final class QuantifierNode extends StateNode {
         AQ,         /* to '*?'   */
         QQ,         /* to '??'   */
         P_QQ,       /* to '+)??' */
-        PQ_Q,       /* to '+?)?' */
     }
 
     static final ReduceType[][]REDUCE_TABLE = {
@@ -146,7 +144,7 @@ public final class QuantifierNode extends StateNode {
       {A,       A,      DEL,    ASIS,   P_QQ,   DEL},  /* '+'  */
       {DEL,     AQ,     AQ,     DEL,    AQ,     AQ},   /* '??' */
       {DEL,     DEL,    DEL,    DEL,    DEL,    DEL},  /* '*?' */
-      {ASIS,    PQ_Q,   DEL,    AQ,     AQ,     DEL}   /* '+?' */
+      {ASIS,    ASIS,   ASIS,   AQ,     AQ,     DEL}   /* '+?' */
     };
 
 
@@ -191,16 +189,6 @@ public final class QuantifierNode extends StateNode {
             other.lower = 1;
             other.upper = REPEAT_INFINITE;
             other.greedy = true;
-            return;
-
-        case PQ_Q:
-            setTarget(other);
-            lower = 0;
-            upper = 1;
-            greedy = true;
-            other.lower = 1;
-            other.upper = REPEAT_INFINITE;
-            other.greedy = false;
             return;
 
         case ASIS:


### PR DESCRIPTION
Some of the quantifier reduction rules in oniguruma are invalid, leading to new regular expressions with different semantics. This PR removes two such reduction rules.

Here they are illustrated. If we introduce a capture group in between the two quantifiers, we prevent the quantifier reduction from triggering, leading to a different result.

```
irb(main):001:0> /(?:a+?)*/.match("aa")
=> #<MatchData "a">
irb(main):002:0> /(a+?)*/.match("aa")
=> #<MatchData "aa" 1:"a">
irb(main):003:0> /(?:a+?)+/.match("aa")
=> #<MatchData "a">
irb(main):004:0> /(a+?)+/.match("aa")
=> #<MatchData "aa" 1:"a">
```

I have reported the issue to MRI Ruby. This PR is a port of their PR.

https://bugs.ruby-lang.org/issues/17341
https://github.com/ruby/ruby/pull/3808