### PR TITLE
[refactor] 'reduce' interrupt check on every iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,14 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
         <executions>
           <execution>
             <id>default-compile</id>
             <configuration>
-              <source>1.7</source>
-              <target>1.7</target>
               <excludes>
                 <exclude>module-info.java</exclude>
               </excludes>

--- a/src/org/joni/Analyser.java
+++ b/src/org/joni/Analyser.java
@@ -114,7 +114,6 @@ final class Analyser extends Parser {
 
         regex.captureHistory = env.captureHistory;
         regex.btMemStart = env.btMemStart;
-        regex.btMemEnd = env.btMemEnd;
 
         if (isFindCondition(regex.options)) {
             regex.btMemEnd = bsAll();
@@ -478,9 +477,6 @@ final class Analyser extends Parser {
             break;
 
         case NodeType.CTYPE:
-            min = 1;
-            break;
-
         case NodeType.CCLASS:
         case NodeType.CANY:
             min = 1;
@@ -559,9 +555,6 @@ final class Analyser extends Parser {
             break;
 
         case NodeType.CTYPE:
-            max = enc.maxLength();
-            break;
-
         case NodeType.CCLASS:
         case NodeType.CANY:
             max = enc.maxLength();
@@ -722,8 +715,6 @@ final class Analyser extends Parser {
             break;
 
         case NodeType.CTYPE:
-            len = 1;
-
         case NodeType.CCLASS:
         case NodeType.CANY:
             len = 1;
@@ -1305,12 +1296,6 @@ final class Analyser extends Parser {
 
         switch(node.getType()) {
         case NodeType.LIST:
-            ListNode ln = (ListNode)node;
-            do {
-                setupSubExpCall(ln.value);
-            } while ((ln = ln.tail) != null);
-            break;
-
         case NodeType.ALT:
             ListNode can = (ListNode)node;
             do {

--- a/src/org/joni/ArrayCompiler.java
+++ b/src/org/joni/ArrayCompiler.java
@@ -652,7 +652,7 @@ final class ArrayCompiler extends Compiler {
             }
         }
 
-        int modTLen = 0;
+        int modTLen;
         if (emptyInfo != 0) {
             modTLen = tlen + (OPSize.NULL_CHECK_START + OPSize.NULL_CHECK_END);
         } else {

--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -37,7 +37,8 @@ import org.joni.exception.ErrorMessages;
 import org.joni.exception.InternalException;
 
 class ByteCodeMachine extends StackMachine {
-    private static final int INTERRUPT_CHECK_EVERY = 30000;
+    private static final int MAX_INTERRUPT_CHECK_EVERY = 256 << 7; // 32768
+    int INTERRUPT_CHECK_EVERY = 256; //   << 1 after each check up to  ^^^
     volatile boolean interrupted = false;
 
     private int bestLen;          // return value
@@ -444,6 +445,7 @@ class ByteCodeMachine extends StackMachine {
             Thread.currentThread().interrupted();
             throw new InterruptedException();
         }
+        INTERRUPT_CHECK_EVERY = Math.min(INTERRUPT_CHECK_EVERY << 1, MAX_INTERRUPT_CHECK_EVERY);
     }
 
     private boolean opEnd() {

--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -60,6 +60,9 @@ class ByteCodeMachine extends StackMachine {
 
     public void interrupt() {
         interrupted = true;
+        // might have no effect on the executing thread but worth a try
+        // we might not succeed interrupting on next loop but will eventually
+        synchronized (this) { INTERRUPT_CHECK_EVERY = 0; }
     }
 
     protected int stkp; // a temporary

--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -26,7 +26,6 @@ import static org.joni.Option.isFindLongest;
 import static org.joni.Option.isFindNotEmpty;
 import static org.joni.Option.isNotBol;
 import static org.joni.Option.isNotEol;
-import static org.joni.Option.isPosixRegion;
 
 import org.jcodings.CodeRange;
 import org.jcodings.Encoding;
@@ -38,7 +37,7 @@ import org.joni.exception.InternalException;
 
 class ByteCodeMachine extends StackMachine {
     private static final int MAX_INTERRUPT_CHECK_EVERY = 256 << 7; // 32768
-    int INTERRUPT_CHECK_EVERY = 256; //   << 1 after each check up to  ^^^
+    int interruptCheckEvery = 256;     // << 1 after each check up to  ^^^
     volatile boolean interrupted = false;
 
     private int bestLen;          // return value
@@ -62,7 +61,7 @@ class ByteCodeMachine extends StackMachine {
         interrupted = true;
         // might have no effect on the executing thread but worth a try
         // we might not succeed interrupting on next loop but will eventually
-        synchronized (this) { INTERRUPT_CHECK_EVERY = 0; }
+        synchronized (this) { interruptCheckEvery = 0; }
     }
 
     protected int stkp; // a temporary
@@ -174,7 +173,7 @@ class ByteCodeMachine extends StackMachine {
         final int[] code = this.code;
         int interruptCheckCounter = 0;
         while (true) {
-            if (interruptCheckCounter++ >= INTERRUPT_CHECK_EVERY) {
+            if (interruptCheckCounter++ >= interruptCheckEvery) {
                 handleInterrupted(checkThreadInterrupt);
                 interruptCheckCounter = 0;
             }
@@ -239,7 +238,7 @@ class ByteCodeMachine extends StackMachine {
                 case OPCode.MEMORY_START_PUSH:          opMemoryStartPush();       continue;
                 case OPCode.MEMORY_START:               opMemoryStart();           continue;
                 case OPCode.MEMORY_END_PUSH:            opMemoryEndPush();         continue;
-                case OPCode.MEMORY_END:                 opMemoryEnd();             continue;
+                case OPCode.MEMORY_END:                 opMemoryEnd();             continue; //
                 case OPCode.KEEP:                       opKeep();                  continue;
                 case OPCode.MEMORY_END_PUSH_REC:        opMemoryEndPushRec();      continue;
                 case OPCode.MEMORY_END_REC:             opMemoryEndRec();          continue;
@@ -309,7 +308,7 @@ class ByteCodeMachine extends StackMachine {
         final int[] code = this.code;
         int interruptCheckCounter = 0;
         while (true) {
-            if (interruptCheckCounter++ >= INTERRUPT_CHECK_EVERY) {
+            if (interruptCheckCounter++ >= interruptCheckEvery) {
                 handleInterrupted(checkThreadInterrupt);
                 interruptCheckCounter = 0;
             }
@@ -448,7 +447,7 @@ class ByteCodeMachine extends StackMachine {
             Thread.currentThread().interrupted();
             throw new InterruptedException();
         }
-        INTERRUPT_CHECK_EVERY = Math.min(INTERRUPT_CHECK_EVERY << 1, MAX_INTERRUPT_CHECK_EVERY);
+        interruptCheckEvery = Math.min(interruptCheckEvery << 1, MAX_INTERRUPT_CHECK_EVERY);
     }
 
     private boolean opEnd() {

--- a/src/org/joni/ByteCodePrinter.java
+++ b/src/org/joni/ByteCodePrinter.java
@@ -376,14 +376,14 @@ class ByteCodePrinter {
     }
 
     private String compiledByteCodeListToString() {
-        StringBuilder sb = new StringBuilder("code length: " + codeLength + "\n");
+        StringBuilder sb = new StringBuilder("code length: ").append(codeLength).append('\n');
         int ncode = -1;
         int bp = 0;
         int end = codeLength;
 
         while (bp < end) {
             ncode++;
-            sb.append(ncode % 5 == 0 ? "\n" : " ");
+            sb.append(ncode % 5 == 0 ? '\n' : ' ');
             bp = compiledByteCodeToString(sb, bp);
         }
         sb.append("\n");

--- a/src/org/joni/ByteCodePrinter.java
+++ b/src/org/joni/ByteCodePrinter.java
@@ -26,7 +26,7 @@ import org.joni.constants.internal.OPSize;
 import org.joni.exception.InternalException;
 
 class ByteCodePrinter {
-    final int[]code;
+    final int[] code;
     final int codeLength;
     final byte[][] templates;
     final Encoding enc;
@@ -43,19 +43,19 @@ class ByteCodePrinter {
     }
 
     private void pString(StringBuilder sb, int len, int s) {
-        sb.append(":");
+        sb.append(':');
         while (len-- > 0) sb.append(new String(new byte[]{(byte)code[s++]}));
     }
 
     private void pLenString(StringBuilder sb, int len, int mbLen, int s) {
         int x = len * mbLen;
-        sb.append(":" + len + ":");
+        sb.append(':').append(len).append(':');
         while (x-- > 0) sb.append(new String(new byte[]{(byte)code[s++]}));
     }
 
     private void pLenStringFromTemplate(StringBuilder sb, int len, int mbLen, byte[]tm, int idx) {
         int x = len * mbLen;
-        sb.append(":T:" + len + ":");
+        sb.append(":T:").append(len).append(':');
         while (x-- > 0) sb.append(new String(tm, idx++, 1));
     }
 
@@ -64,7 +64,7 @@ class ByteCodePrinter {
         BitSet bs;
         int tm, idx;
 
-        sb.append("[" + OPCode.OpCodeNames[code[bp]]);
+        sb.append('[').append(OPCode.OpCodeNames[code[bp]]);
         int argType = OPCode.OpCodeArgTypes[code[bp]];
         int ip = bp;
         if (argType != Arguments.SPECIAL) {
@@ -74,32 +74,32 @@ class ByteCodePrinter {
                 break;
 
             case Arguments.RELADDR:
-                sb.append(":(" + code[bp] + ")");
+                sb.append(":(").append(code[bp]).append(')');
                 bp += OPSize.RELADDR;
                 break;
 
             case Arguments.ABSADDR:
-                sb.append(":(" + code[bp] + ")");
+                sb.append(":(").append(code[bp]).append(')');
                 bp += OPSize.ABSADDR;
                 break;
 
             case Arguments.LENGTH:
-                sb.append(":" + code[bp]);
+                sb.append(':').append(code[bp]);
                 bp += OPSize.LENGTH;
                 break;
 
             case Arguments.MEMNUM:
-                sb.append(":" + code[bp]);
+                sb.append(':').append(code[bp]);
                 bp += OPSize.MEMNUM;
                 break;
 
             case Arguments.OPTION:
-                sb.append(":" + code[bp]);
+                sb.append(':').append(code[bp]);
                 bp += OPSize.OPTION;
                 break;
 
             case Arguments.STATE_CHECK:
-                sb.append(":" + code[bp]);
+                sb.append(':').append(code[bp]);
                 bp += OPSize.STATE_CHECK;
                 break;
             }
@@ -203,10 +203,10 @@ class ByteCodePrinter {
                     bp += OPSize.INDEX;
                     idx = code[bp];
                     bp += OPSize.INDEX;
-                    sb.append(":T:" + mbLen + ":" + len + ":");
+                    sb.append(":T:").append(mbLen).append(":").append(len).append(":");
                     while (n-- > 0) sb.append(new String(templates[tm], idx++, 1));
                 } else {
-                    sb.append(":" + mbLen + ":" + len + ":");
+                    sb.append(":").append(mbLen).append(":").append(len).append(":");
                     while (n-- > 0) sb.append(new String(new byte[]{(byte)code[bp++]}));
                 }
 
@@ -243,7 +243,7 @@ class ByteCodePrinter {
                 System.arraycopy(code, bp, bs.bits, 0, BitSet.BITSET_SIZE);
                 n = bs.numOn();
                 bp += BitSet.BITSET_SIZE;
-                sb.append(":" + n);
+                sb.append(':').append(n);
                 break;
 
             case OPCode.CCLASS_NOT:
@@ -251,7 +251,7 @@ class ByteCodePrinter {
                 System.arraycopy(code, bp, bs.bits, 0, BitSet.BITSET_SIZE);
                 n = bs.numOn();
                 bp += BitSet.BITSET_SIZE;
-                sb.append(":" + n);
+                sb.append(':').append(n);
                 break;
 
             case OPCode.CCLASS_MB:
@@ -261,7 +261,7 @@ class ByteCodePrinter {
                 cod = code[bp];
                 //bp += OPSize.CODE_POINT;
                 bp += len;
-                sb.append(":" + cod + ":" + len);
+                sb.append(':').append(cod).append(':').append(len);
                 break;
 
             case OPCode.CCLASS_MIX:
@@ -275,18 +275,18 @@ class ByteCodePrinter {
                 cod = code[bp];
                 //bp += OPSize.CODE_POINT;
                 bp += len;
-                sb.append(":" + n + ":" + cod + ":" + len);
+                sb.append(':').append(n).append(':').append(cod).append(':').append(len);
                 break;
 
             case OPCode.BACKREFN_IC:
                 mem = code[bp];
                 bp += OPSize.MEMNUM;
-                sb.append(":" + mem);
+                sb.append(':').append(mem);
                 break;
 
             case OPCode.BACKREF_MULTI_IC:
             case OPCode.BACKREF_MULTI:
-                sb.append(" ");
+                sb.append(' ');
                 len = code[bp];
                 bp += OPSize.LENGTH;
                 for (int i=0; i<len; i++) {
@@ -300,11 +300,11 @@ class ByteCodePrinter {
             case OPCode.BACKREF_WITH_LEVEL: {
                 int option = code[bp];
                 bp += OPSize.OPTION;
-                sb.append(":" + option);
+                sb.append(':').append(option);
                 int level = code[bp];
                 bp += OPSize.LENGTH;
-                sb.append(":" + level);
-                sb.append(" ");
+                sb.append(':').append(level);
+                sb.append(' ');
                 len = code[bp];
                 bp += OPSize.LENGTH;
                 for (int i=0; i<len; i++) {
@@ -322,14 +322,14 @@ class ByteCodePrinter {
                 bp += OPSize.MEMNUM;
                 addr = code[bp];
                 bp += OPSize.RELADDR;
-                sb.append(":" + mem + ":" + addr);
+                sb.append(':').append(mem).append(':').append(addr);
                 break;
 
             case OPCode.PUSH_OR_JUMP_EXACT1:
             case OPCode.PUSH_IF_PEEK_NEXT:
                 addr = code[bp];
                 bp += OPSize.RELADDR;
-                sb.append(":(" + addr + ")");
+                sb.append(":(").append(addr).append(')');
                 pString(sb, 1, bp);
                 bp++;
                 break;
@@ -337,7 +337,7 @@ class ByteCodePrinter {
             case OPCode.LOOK_BEHIND:
                 len = code[bp];
                 bp += OPSize.LENGTH;
-                sb.append(":" + len);
+                sb.append(':').append(len);
                 break;
 
             case OPCode.PUSH_LOOK_BEHIND_NOT:
@@ -345,7 +345,7 @@ class ByteCodePrinter {
                 bp += OPSize.RELADDR;
                 len = code[bp];
                 bp += OPSize.LENGTH;
-                sb.append(":" + len + ":(" + addr + ")");
+                sb.append(':').append(len).append(":(").append(addr).append(')');
                 break;
 
             case OPCode.STATE_CHECK_PUSH:
@@ -354,7 +354,7 @@ class ByteCodePrinter {
                 bp += OPSize.STATE_CHECK_NUM;
                 addr = code[bp];
                 bp += OPSize.RELADDR;
-                sb.append(":" + scn + ":(" + addr + ")");
+                sb.append(':').append(scn).append(":(").append(addr).append(')');
                 break;
 
             case OPCode.CONDITION:
@@ -362,7 +362,7 @@ class ByteCodePrinter {
                 bp += OPSize.MEMNUM;
                 addr = code[bp];
                 bp += OPSize.RELADDR;
-                sb.append(":" + mem + ":" + addr);
+                sb.append(':').append(mem).append(":").append(addr);
                 break;
 
             default:
@@ -370,8 +370,8 @@ class ByteCodePrinter {
             }
         }
 
-        sb.append("]");
-        if (Config.DEBUG_COMPILE_BYTE_CODE_INFO) sb.append("@" + ip + "(" + (bp - ip) + ")");
+        sb.append(']');
+        if (Config.DEBUG_COMPILE_BYTE_CODE_INFO) sb.append('@').append(ip).append('(').append(bp - ip).append(')');
         return bp;
     }
 

--- a/src/org/joni/Lexer.java
+++ b/src/org/joni/Lexer.java
@@ -494,7 +494,7 @@ class Lexer extends ScannerSupport {
         int to = this.stop;
 
         boolean inEsc = false;
-        int i=0;
+        int i;
         while(p < to) {
             if (inEsc) {
                 inEsc = false;

--- a/src/org/joni/MinMaxLen.java
+++ b/src/org/joni/MinMaxLen.java
@@ -54,9 +54,7 @@ final class MinMaxLen {
         if (v2 > v1) return 1;
         if (v2 < v1) return -1;
 
-        if (other.min < min) return 1;
-        if (other.min > min) return -1;
-        return 0;
+        return Integer.compare(min, other.min);
     }
 
     boolean equal(MinMaxLen other) {

--- a/src/org/joni/OptAnchorInfo.java
+++ b/src/org/joni/OptAnchorInfo.java
@@ -79,7 +79,7 @@ final class OptAnchorInfo implements AnchorType {
     }
 
     static String anchorToString(int anchor) {
-        StringBuffer s = new StringBuffer("[");
+        StringBuilder s = new StringBuilder("[");
 
         if ((anchor & AnchorType.BEGIN_BUF) !=0 ) s.append("begin-buf ");
         if ((anchor & AnchorType.BEGIN_LINE) !=0 ) s.append("begin-line ");

--- a/src/org/joni/OptExactInfo.java
+++ b/src/org/joni/OptExactInfo.java
@@ -73,7 +73,7 @@ final class OptExactInfo {
         }
 
         length = i;
-        reachEnd = (p == end ? other.reachEnd : false);
+        reachEnd = (p == end && other.reachEnd);
 
         OptAnchorInfo tmp = new OptAnchorInfo();
         tmp.concat(anchor, other.anchor, 1, 1);

--- a/src/org/joni/Parser.java
+++ b/src/org/joni/Parser.java
@@ -648,8 +648,7 @@ class Parser extends Lexer {
                     } // switch
 
                     if (c == ')') {
-                        EncloseNode en = EncloseNode.newOption(option);
-                        node = en;
+                        node = EncloseNode.newOption(option);
                         returnCode = 2; /* option only */
                         return node;
                     } else if (c == ':') {
@@ -680,8 +679,7 @@ class Parser extends Lexer {
                 return node;
             }
             EncloseNode en = EncloseNode.newMemory(env.option, false);
-            int num = env.addMemEntry();
-            en.regNum = num;
+            en.regNum = env.addMemEntry();
             node = en;
         }
 
@@ -715,27 +713,25 @@ class Parser extends Lexer {
 
     private Node parseEncloseNamedGroup2(boolean listCapture) {
         int nm = p;
-        int num = fetchName(c, false);
+        fetchName(c, false);
         int nameEnd = value;
-        num = env.addMemEntry();
+        int num = env.addMemEntry();
         if (listCapture && num >= BitStatus.BIT_STATUS_BITS_NUM) newValueException(GROUP_NUMBER_OVER_FOR_CAPTURE_HISTORY);
 
         regex.nameAdd(bytes, nm, nameEnd, num, syntax);
         EncloseNode en = EncloseNode.newMemory(env.option, true);
         en.regNum = num;
 
-        Node node = en;
-
         if (listCapture) env.captureHistory = bsOnAtSimple(env.captureHistory, num);
         env.numNamed++;
-        return node;
+        return en;
     }
 
     private int findStrPosition(int[]s, int n, int from, int to, Ptr nextChar) {
         int x;
         int q;
         int p = from;
-        int i = 0;
+        int i;
         while (p < to) {
             x = enc.mbcToCode(bytes, p, to);
             q = p + enc.length(bytes, p, to);
@@ -955,7 +951,7 @@ class Parser extends Lexer {
         return np;
     }
 
-    private static int NODE_COMMON_SIZE = 16;
+    private static final int NODE_COMMON_SIZE = 16;
     private Node parseExtendedGraphemeCluster() {
         final Node[] nodes = new Node[NODE_COMMON_SIZE];
         final int anyTargetPosition;

--- a/src/org/joni/Parser.java
+++ b/src/org/joni/Parser.java
@@ -922,7 +922,7 @@ class Parser extends Lexer {
             case '+':  lower = 1;          break;
             case '*':                      break;
             case '2':  lower = upper = 2;  break;
-            default :  new InternalException(ErrorMessages.PARSER_BUG);
+            default :  throw new InternalException(ErrorMessages.PARSER_BUG);
         }
 
         quantifierNode(nodes, np, lower, upper);

--- a/src/org/joni/Regex.java
+++ b/src/org/joni/Regex.java
@@ -257,7 +257,7 @@ public final class Regex {
         if (nameTable != null) {
             sb.append("name table\n");
             for (NameEntry ne : nameTable) {
-                sb.append("  " + ne + "\n");
+                sb.append("  ").append(ne).append("\n");
             }
             sb.append("\n");
         }

--- a/src/org/joni/UnsetAddrList.java
+++ b/src/org/joni/UnsetAddrList.java
@@ -50,7 +50,7 @@ public final class UnsetAddrList {
     public void fix(Regex regex) {
         for (int i=0; i<num; i++) {
             EncloseNode en = targets[i];
-            if (!en.isAddrFixed()) new InternalException(ErrorMessages.PARSER_BUG);
+            if (!en.isAddrFixed()) throw new InternalException(ErrorMessages.PARSER_BUG);
             regex.code[offsets[i]] = en.callAddr; // is this safe ?
         }
     }

--- a/src/org/joni/UnsetAddrList.java
+++ b/src/org/joni/UnsetAddrList.java
@@ -58,7 +58,9 @@ public final class UnsetAddrList {
     public String toString() {
         StringBuilder value = new StringBuilder();
         if (num > 0) {
-            for (int i = 0; i < num; i++) value.append("offset + " + offsets[i] + " target: " + targets[i].getAddressName());
+            for (int i = 0; i < num; i++) {
+                value.append("offset + ").append(offsets[i]).append(" target: ").append(targets[i].getAddressName());
+            }
         }
         return value.toString();
     }


### PR DESCRIPTION
not super clean but helps non-interruptible cases to match ~4% faster :

best out of few runs before:
```
                                                     user     system      total        real
Regexp#match simple (str.size: 390 [10000000x]  10.490000   0.000000  10.490000 ( 10.148109)
Regexp#match simple (str.size: 7 [10000000x]     2.880000   0.010000   2.890000 (  2.783566)
Regexp#match complex (str.size: 30 [10000x]     26.120000   0.000000  26.120000 ( 26.120740)
```
after:
```
                                                     user     system      total        real
Regexp#match simple (str.size: 390 [10000000x]   9.850000   0.000000   9.850000 (  9.782038)
Regexp#match simple (str.size: 7 [10000000x]     2.770000   0.000000   2.770000 (  2.680357)
Regexp#match complex (str.size: 30 [10000x]     25.220000   0.000000  25.220000 ( 25.217796)
```

also cleaned up warnings - most importantly a place or two where `throw` was missed.