### PR TITLE
Add ability to specify gpos in search

### DIFF
--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -1309,7 +1309,7 @@ class ByteCodeMachine extends StackMachine {
     }
 
     private void opBeginPosition() {
-        if (s != msaStart) opFail();
+        if (s != msaGpos) opFail();
     }
 
     private void opMemoryStartPush() {

--- a/test/org/joni/test/TestA.java
+++ b/test/org/joni/test/TestA.java
@@ -542,5 +542,14 @@ public class TestA extends Test {
         x2s("([.])", ".", 0, 1);
         x2s("([a])", "a", 0, 1);
         x2s("([\\w])", "a", 0, 1);
+
+        // gpos
+        ns("\\Gabc", "123abcdef", 2, Option.DEFAULT);
+        x2s("\\Gabc", "123abcdef", 3, 0, 3, 6);
+        x2s("\\Gabc", "123abcdef", 3, 3, 3, 6);
+        ns("\\Gabc", "123abcdef", 0, 3);
+
+        x2s("(?!\\G)", "abcd", 2, 3, 3, 3);
+        x2s("(?!\\G)", "abcd", 3, 3, 4, 4);
     }
 }


### PR DESCRIPTION
In Onigmo, it is possible to specify the position of `\G` by calling the function [`onig_search_gpos`](https://github.com/k-takata/Onigmo/blob/a06a42b51713eeafe30a939827031c3ba79da936/regexec.c#L3794).

This is an implementation of this functionality, as discussed in https://github.com/jruby/joni/issues/49