### PR TITLE
Encapsulate fields of Region

### DIFF
--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -98,10 +98,10 @@ class ByteCodeMachine extends StackMachine {
 
     private void checkCaptureHistory(Region region) {
         CaptureTreeNode node;
-        if (region.historyRoot == null) {
-            node = region.historyRoot = new CaptureTreeNode();
+        if (region.getCaptureTree() == null) {
+            node = region.setCaptureTree(new CaptureTreeNode());
         } else {
-            node = region.historyRoot;
+            node = region.getCaptureTree();
             node.clear();
         }
 
@@ -111,7 +111,7 @@ class ByteCodeMachine extends StackMachine {
         node.end = s      - str;
 
         stkp = 0;
-        makeCaptureHistoryTree(region.historyRoot);
+        makeCaptureHistoryTree(region.getCaptureTree());
     }
 
     private byte[]cfbuf;
@@ -470,16 +470,17 @@ class ByteCodeMachine extends StackMachine {
             final Region region = msaRegion;
             if (region != null) {
                 // USE_POSIX_REGION_OPTION ... else ...
-                region.beg[0] = msaBegin = ((pkeep > s) ? s : pkeep) - str;
-                region.end[0] = msaEnd   = s      - str;
+                region.setBeg(0, msaBegin = ((pkeep > s) ? s : pkeep) - str);
+                region.setEnd(0, msaEnd   = s      - str);
                 for (int i = 1; i <= regex.numMem; i++) {
                     int me = repeatStk[memEndStk + i];
                     if (me != INVALID_INDEX) {
                         int ms = repeatStk[memStartStk + i];
-                        region.beg[i] = (bsAt(regex.btMemStart, i) ? stack[ms].getMemPStr() : ms) - str;
-                        region.end[i] = (bsAt(regex.btMemEnd, i) ? stack[me].getMemPStr() : me) - str;
+                        region.setBeg(i, (bsAt(regex.btMemStart, i) ? stack[ms].getMemPStr() : ms) - str);
+                        region.setEnd(i, (bsAt(regex.btMemEnd, i) ? stack[me].getMemPStr() : me) - str);
                     } else {
-                        region.beg[i] = region.end[i] = Region.REGION_NOTPOS;
+                        region.setBeg(i, Region.REGION_NOTPOS);
+                        region.setEnd(i, Region.REGION_NOTPOS);
                     }
                 }
 

--- a/src/org/joni/Regex.java
+++ b/src/org/joni/Regex.java
@@ -244,7 +244,7 @@ public final class Regex {
         default:
             if (region != null) {
                 for (int i = e.backNum - 1; i >= 0; i--) {
-                    if (region.beg[e.backRefs[i]] != Region.REGION_NOTPOS) return e.backRefs[i];
+                    if (region.getBeg(e.backRefs[i]) != Region.REGION_NOTPOS) return e.backRefs[i];
                 }
             }
             return e.backRefs[e.backNum - 1];

--- a/src/org/joni/Region.java
+++ b/src/org/joni/Region.java
@@ -22,23 +22,30 @@ package org.joni;
 public final class Region {
     static final int REGION_NOTPOS = -1;
 
+    @Deprecated
     public final int numRegs;
-    public final int[]beg;
-    public final int[]end;
+    @Deprecated
+    public final int[] beg;
+    @Deprecated
+    public final int[] end;
+    @Deprecated
     public CaptureTreeNode historyRoot;
 
+    @SuppressWarnings("deprecation")
     public Region(int num) {
         this.numRegs = num;
         this.beg = new int[num];
         this.end = new int[num];
     }
 
+    @SuppressWarnings("deprecation")
     public Region(int begin, int end) {
         this.numRegs = 1;
         this.beg = new int[]{begin};
         this.end = new int[]{end};
     }
 
+    @SuppressWarnings("deprecation")
     public Region clone() {
         Region region = new Region(numRegs);
         System.arraycopy(beg, 0, region.beg, 0, beg.length);
@@ -47,6 +54,32 @@ public final class Region {
         return region;
     }
 
+    @SuppressWarnings("deprecation")
+    public int getNumRegs() {
+        return numRegs;
+    }
+
+    @SuppressWarnings("deprecation")
+    public int getBeg(int index) {
+        return beg[index];
+    }
+
+    @SuppressWarnings("deprecation")
+    public int setBeg(int index, int value) {
+        return beg[index] = value;
+    }
+
+    @SuppressWarnings("deprecation")
+    public int getEnd(int index) {
+        return end[index];
+    }
+
+    @SuppressWarnings("deprecation")
+    public int setEnd(int index, int value) {
+        return end[index] = value;
+    }
+
+    @SuppressWarnings("deprecation")
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Region: \n");
@@ -54,10 +87,17 @@ public final class Region {
         return sb.toString();
     }
 
+    @SuppressWarnings("deprecation")
     CaptureTreeNode getCaptureTree() {
         return historyRoot;
     }
 
+    @SuppressWarnings("deprecation")
+    CaptureTreeNode setCaptureTree(CaptureTreeNode ctn) {
+        return this.historyRoot = ctn;
+    }
+
+    @SuppressWarnings("deprecation")
     void clear() {
         for (int i=0; i<beg.length; i++) {
             beg[i] = end[i] = REGION_NOTPOS;

--- a/test/org/joni/test/Test.java
+++ b/test/org/joni/test/Test.java
@@ -177,13 +177,13 @@ public abstract class Test {
                 Config.log.println("FAIL(NOT): " + reprTest(pattern, str, option));
                 nfail++;
             } else {
-                if (region.beg[mem] == from && region.end[mem] == to) {
+                if (region.getBeg(mem) == from && region.getEnd(mem) == to) {
                     if (VERBOSE) Config.log.println("OK: " + reprTest(pattern, str, option));
                     nsucc++;
                 } else {
                     Config.log.println("FAIL: " + reprTest(pattern, str, option) + " GPOS: " + gpos + " Start: "
-                            + searchStart + " Groups: [Exp " + from + "-" + to + ", Act " + region.beg[mem] + "-"
-                            + region.end[mem] + "]");
+                            + searchStart + " Groups: [Exp " + from + "-" + to + ", Act " + region.getBeg(mem) + "-"
+                            + region.getEnd(mem) + "]");
                     nfail++;
                 }
             }


### PR DESCRIPTION
There are optimizations we could make here if the beg and end fields were encapsulated that are impossible with them public. The other fields should just be encapsulated as good practice.

We will do one release with these fields still public but deprecated, and then a larger version bump when we make them private.