### PR TITLE
Move to a factory method for Region instances

### DIFF
--- a/src/org/joni/Matcher.java
+++ b/src/org/joni/Matcher.java
@@ -71,7 +71,7 @@ public abstract class Matcher extends IntHolder {
     }
 
     public final Region getEagerRegion() {
-        return msaRegion != null ? msaRegion : new Region(msaBegin, msaEnd);
+        return msaRegion != null ? msaRegion : Region.newRegion(msaBegin, msaEnd);
     }
 
     public final int getBegin() {

--- a/src/org/joni/Regex.java
+++ b/src/org/joni/Regex.java
@@ -164,7 +164,7 @@ public final class Regex {
     }
 
     public Matcher matcher(byte[]bytes, int p, int end) {
-        return factory.create(this, numMem == 0 ? null : new Region(numMem + 1), bytes, p, end);
+        return factory.create(this, numMem == 0 ? null : Region.newRegion(numMem + 1), bytes, p, end);
     }
 
     public Matcher matcherNoRegion(byte[]bytes, int p, int end) {

--- a/src/org/joni/Region.java
+++ b/src/org/joni/Region.java
@@ -32,12 +32,24 @@ public final class Region {
     public CaptureTreeNode historyRoot;
 
     @SuppressWarnings("deprecation")
+    public static Region newRegion(int num) {
+        return new Region(num);
+    }
+
+    @SuppressWarnings("deprecation")
+    public static Region newRegion(int begin, int end) {
+        return new Region(begin, end);
+    }
+
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public Region(int num) {
         this.numRegs = num;
         this.beg = new int[num];
         this.end = new int[num];
     }
 
+    @Deprecated
     @SuppressWarnings("deprecation")
     public Region(int begin, int end) {
         this.numRegs = 1;


### PR DESCRIPTION
In order to specialize Region based on width, we need consumers to stop instantiating it directly. This commit deprecates the two Region constructors, replacing them with newRegion factory methods we can use in the future to construct specialized Region shapes.

This feature will have to be in the wild for some time to allow JRuby and libraries like strscan to move to the updated API. At some point in the future, we can major rev joni and remove the deprecated constructors and public fields.