### PR TITLE
[test] reproduce jruby/jruby#7730

### DIFF
--- a/test/org/joni/test/TestCaseInsensitive.java
+++ b/test/org/joni/test/TestCaseInsensitive.java
@@ -1,0 +1,32 @@
+package org.joni.test;
+
+import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Option;
+import org.joni.Syntax;
+
+public class TestCaseInsensitive extends Test {
+
+    @Override
+    public int option() {
+        return Option.IGNORECASE;
+    }
+    @Override
+    public Encoding encoding() {
+        return UTF8Encoding.INSTANCE;
+    }
+    @Override
+    public String testEncoding() {
+        return "utf-8";
+    }
+    @Override
+    public Syntax syntax() {
+        return Syntax.TEST;
+    }
+
+    @Override
+    public void test() throws Exception {
+        xx("^\\d\\d\\d-".getBytes(), new byte[]{-30, -126, -84, 48, 45}, 0, 0, 0, true);
+        x2s("ab", "\uD835\uDC4D ab", 5, 7);
+    }
+}


### PR DESCRIPTION
just a reproducer/test for: https://github.com/jruby/jruby/issues/7730 ... ~~currently~~ was failing as:
```
Pattern: Pattern: [/ab/] Str: ["𝑍 ab"] Encoding: [UTF-8] Option: [IGNORECASE] Syntax: [TEST]
java.lang.ArrayIndexOutOfBoundsException: Index -3 out of bounds for length 7
	at org.jruby.jcodings@1.0.58/org.jcodings.specific.BaseUTF8Encoding.mbcCaseFold(BaseUTF8Encoding.java:154)
	at org.jruby.jcodings@1.0.58/org.jcodings.specific.UTF8Encoding.mbcCaseFold(UTF8Encoding.java:22)
	at org.jruby.joni/org.joni.Search.lowerCaseMatch(Search.java:42)
	at org.jruby.joni/org.joni.Search.access$000(Search.java:27)
	at org.jruby.joni/org.joni.Search$11.search(Search.java:439)
	at org.jruby.joni/org.joni.Matcher.forwardSearchRange(Matcher.java:139)
	at org.jruby.joni/org.joni.Matcher.searchCommon(Matcher.java:447)
	at org.jruby.joni/org.joni.Matcher.searchInterruptible(Matcher.java:322)
	at org.jruby.joni/org.joni.test.Test.check(Test.java:148)
	at org.jruby.joni/org.joni.test.Test.xx(Test.java:140)
	at org.jruby.joni/org.joni.test.Test.xx(Test.java:114)
	at org.jruby.joni/org.joni.test.Test.x2s(Test.java:237)
	at org.jruby.joni/org.joni.test.Test.x2s(Test.java:232)
	at org.jruby.joni/org.joni.test.TestCaseInsensitive.test(TestCaseInsensitive.java:30)
	at org.jruby.joni/org.joni.test.Test.testRegexp(Test.java:287)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
SEVERE ERROR: Index -3 out of bounds for length 7
RESULT   SUCC: 1,  FAIL: 0,  ERROR: 1 Test: TestCaseInsensitive, Encoding: UTF-8
```