### PR TITLE
Fix issue 63 (and 2 related issues)

### DIFF
--- a/src/org/joni/Lexer.java
+++ b/src/org/joni/Lexer.java
@@ -1324,7 +1324,7 @@ class Lexer extends ScannerSupport {
 
     protected final void syntaxWarn(String message) {
         if (env.warnings != WarnCallback.NONE) {
-            env.warnings.warn(message + ": /" + new String(bytes, getBegin(), getEnd()) + "/");
+            env.warnings.warn(message + ": /" + new String(bytes, getBegin(), getEnd() - getBegin()) + "/");
         }
     }
 }

--- a/src/org/joni/ast/QuantifierNode.java
+++ b/src/org/joni/ast/QuantifierNode.java
@@ -238,11 +238,11 @@ public final class QuantifierNode extends StateNode {
                     case ASIS:
                         break;
                     case DEL:
-                        env.warnings.warn("regular expression has redundant nested repeat operator " + PopularQStr[targetQNum] + " /" + new String(bytes, p, end) + "/");
+                        env.warnings.warn("regular expression has redundant nested repeat operator " + PopularQStr[targetQNum] + " /" + new String(bytes, p, end - p) + "/");
                         break;
                     default:
                         env.warnings.warn("nested repeat operator '" + PopularQStr[targetQNum] + "' and '" + PopularQStr[nestQNum] +
-                                "' was replaced with '" + ReduceQStr[REDUCE_TABLE[targetQNum][nestQNum].ordinal()] + "' in regular expression " + "/" + new String(bytes, p, end) + "/");
+                                "' was replaced with '" + ReduceQStr[REDUCE_TABLE[targetQNum][nestQNum].ordinal()] + "' in regular expression " + "/" + new String(bytes, p, end - p) + "/");
                     }
                 }
             } // USE_WARNING_REDUNDANT_NESTED_REPEAT_OPERATOR

--- a/test/org/joni/test/TestA.java
+++ b/test/org/joni/test/TestA.java
@@ -23,6 +23,7 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.joni.Option;
 import org.joni.Syntax;
+import org.joni.WarnCallback;
 import org.joni.exception.ErrorMessages;
 
 public class TestA extends Test {
@@ -165,6 +166,7 @@ public class TestA extends Test {
         x2s("xyz\\Z", "xyz", 0, 3);
         x2s("xyz\\z", "xyz", 0, 3);
         x2s("a\\Z", "a", 0, 1);
+        x2s("0\\gA", 1, 4, "doesntMatter", 0, 0, true, WarnCallback.DEFAULT);
         x2s("\\Gaz", "az", 0, 2);
         ns("\\Gz", "bza");
         ns("az\\G", "az");

--- a/test/org/joni/test/TestError.java
+++ b/test/org/joni/test/TestError.java
@@ -23,6 +23,7 @@ import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.joni.Option;
 import org.joni.Syntax;
+import org.joni.WarnCallback;
 import org.joni.exception.ErrorMessages;
 
 public class TestError extends Test {
@@ -62,6 +63,8 @@ public class TestError extends Test {
 	    xerrs("\\((", ErrorMessages.END_PATTERN_WITH_UNMATCHED_PARENTHESIS);
 	    xerrs("(|", ErrorMessages.END_PATTERN_WITH_UNMATCHED_PARENTHESIS);
 	    xerrs("'/g\\\u00ff\u00ff\u00ff\u00ff&))", ErrorMessages.UNMATCHED_CLOSE_PARENTHESIS);
+	    xerrs("0'/g\\\u00ff\u00ff\u00ff\u00ff&))", 1, 12, ErrorMessages.UNMATCHED_CLOSE_PARENTHESIS, WarnCallback.DEFAULT);
+	    xerrs("0\\1**?", 1, 6, ErrorMessages.INVALID_BACKREF, WarnCallback.DEFAULT);
 	    xerrs("[0-0-\u00ff  ", ErrorMessages.PREMATURE_END_OF_CHAR_CLASS); // \xe2
 	    xerrs("\\p{foobarbaz}", ErrorMessages.ERR_INVALID_CHAR_PROPERTY_NAME.replace("%n", "foobarbaz"));
 	    //xerrs("\\p{あ}", ErrorMessages.ERR_INVALID_CHAR_PROPERTY_NAME.replace("%n", "あ"));


### PR DESCRIPTION
Fixes issue #63 and 2 related issues; includes test cases.

Found the 2 related issues by creating an IntelliJ Structural Search for suspicious calls to that `String` constructor where the parameter that should be a length looks like an end.

![image](https://github.com/jruby/joni/assets/179091/ed08a3e2-23bc-4d98-89d8-3432330d1593)
