### PR TITLE
Fix invalid character handling

### DIFF
--- a/src/org/joni/Lexer.java
+++ b/src/org/joni/Lexer.java
@@ -1174,7 +1174,12 @@ class Lexer extends ScannerSupport {
                         token.type = TokenType.CODE_POINT;
                         token.setCode(c);
                     } else { /* string */
-                        p = token.backP + enc.length(bytes, token.backP, stop);
+                        int encLength = enc.length(bytes, token.backP, stop);
+                        /* Check and ensure the encoded character is valid */
+                        if (encLength == Encoding.CHAR_INVALID) {
+                            throw new IllegalArgumentException("Invalid character found.");
+                        }
+                        p = token.backP + encLength;
                     }
                     break;
                 } // switch (c)

--- a/src/org/joni/Lexer.java
+++ b/src/org/joni/Lexer.java
@@ -24,6 +24,7 @@ import static org.joni.Option.isSingleline;
 import static org.joni.Option.isWordBoundAllRange;
 import static org.joni.ast.QuantifierNode.isRepeatInfinite;
 
+import org.jcodings.Encoding;
 import org.jcodings.Ptr;
 import org.jcodings.constants.CharacterType;
 import org.jcodings.exception.CharacterPropertyException;


### PR DESCRIPTION
This fixes an unwrapped ArrayIndexOutOfBoundException in src/org/joni/ScannerSupport.

In the Lexar class, it uses the `Encoding.length()` method to retrieve the encoding characters length. According to https://github.com/jruby/jcodings/blob/master/src/org/jcodings/specific/UTF8Encoding.java, the `length()` method could return `CHAR_INVALID` (equals to -1) if the given character is invalid. The logic in Lexer does not check this return value and use it directly to change the index p. This could result in negative p value and affect future code which use p as array index like the code in https://github.com/jruby/joni/blob/master/src/org/joni/ScannerSupport.java#L136. As a result, an unexpected ArrayIndexOutOfBoundException is thrown.

This PR fixes the bug by adding a conditional check for the return result of the `Encoding.length()` method before using it. An IllegalArgumentException is thrown to indicate there is invalid character in the provided regex which is more "informative" for the user instead of the general ArrayIndexOutOfBoundException.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated joni (https://github.com/google/oss-fuzz/pull/10680). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.
