### PR TITLE
Add limit for regex length

### DIFF
--- a/src/org/joni/Config.java
+++ b/src/org/joni/Config.java
@@ -22,6 +22,7 @@ package org.joni;
 import java.io.PrintStream;
 
 public interface Config extends org.jcodings.Config {
+    final int REGEX_MAX_LENGTH = ConfigSupport.getInt("joni.regex_max_length", 10000);
     final int CHAR_TABLE_SIZE = ConfigSupport.getInt("joni.char_table_size", 256);
     final boolean USE_NO_INVALID_QUANTIFIER = ConfigSupport.getBoolean("joni.use_no_invalid_quantifier", true);
     final int SCANENV_MEMNODES_SIZE = ConfigSupport.getInt("joni.scanenv_memnodes_size", 8);

--- a/src/org/joni/Regex.java
+++ b/src/org/joni/Regex.java
@@ -38,10 +38,9 @@ import org.joni.constants.internal.AnchorType;
 import org.joni.exception.ErrorMessages;
 import org.joni.exception.InternalException;
 import org.joni.exception.ValueException;
+import org.joni.Config;
 
 public final class Regex {
-    private final int MAX_LENGTH = 10000; /* For limiting the lenght of the regex pattern */
-
     int[] code;             /* compiled pattern */
     int codeLength;
     boolean requireStack;
@@ -152,8 +151,8 @@ public final class Regex {
 
     // onig_alloc_init
     public Regex(byte[]bytes, int p, int end, int option, int caseFoldFlag, Encoding enc, Syntax syntax, WarnCallback warnings) {
-        if (bytes.length > MAX_LENGTH) {
-            throw new ValueException(errorMessages.REGEX_TOO_LONG);
+        if (bytes.length > Config.REGEX_MAX_LENGTH) {
+            throw new ValueException(ErrorMessages.REGEX_TOO_LONG);
         }
 
         if ((option & (Option.DONT_CAPTURE_GROUP | Option.CAPTURE_GROUP)) ==

--- a/src/org/joni/Regex.java
+++ b/src/org/joni/Regex.java
@@ -40,6 +40,8 @@ import org.joni.exception.InternalException;
 import org.joni.exception.ValueException;
 
 public final class Regex {
+    private final int MAX_LENGTH = 10000; /* For limiting the lenght of the regex pattern */
+
     int[] code;             /* compiled pattern */
     int codeLength;
     boolean requireStack;
@@ -150,6 +152,9 @@ public final class Regex {
 
     // onig_alloc_init
     public Regex(byte[]bytes, int p, int end, int option, int caseFoldFlag, Encoding enc, Syntax syntax, WarnCallback warnings) {
+        if (bytes.length > MAX_LENGTH) {
+            throw new ValueException(errorMessages.REGEX_TOO_LONG);
+        }
 
         if ((option & (Option.DONT_CAPTURE_GROUP | Option.CAPTURE_GROUP)) ==
             (Option.DONT_CAPTURE_GROUP | Option.CAPTURE_GROUP)) {

--- a/src/org/joni/Regex.java
+++ b/src/org/joni/Regex.java
@@ -151,7 +151,7 @@ public final class Regex {
 
     // onig_alloc_init
     public Regex(byte[]bytes, int p, int end, int option, int caseFoldFlag, Encoding enc, Syntax syntax, WarnCallback warnings) {
-        if (bytes.length > Config.REGEX_MAX_LENGTH) {
+        if ((end - p) > Config.REGEX_MAX_LENGTH) {
             throw new ValueException(ErrorMessages.REGEX_TOO_LONG);
         }
 

--- a/src/org/joni/exception/ErrorMessages.java
+++ b/src/org/joni/exception/ErrorMessages.java
@@ -32,6 +32,7 @@ public interface ErrorMessages extends org.jcodings.exception.ErrorMessages {
     final String INVALID_ARGUMENT = "invalid argument";
 
     /* syntax error */
+    final String REGEX_TOO_LONG = "regex length too long";
     final String END_PATTERN_AT_LEFT_BRACE = "end pattern at left brace";
     final String END_PATTERN_AT_LEFT_BRACKET = "end pattern at left bracket";
     final String EMPTY_CHAR_CLASS = "empty char-class";


### PR DESCRIPTION
This fixes a possible out of stack memory problem in src/org/joni/Regex.java for parsing long and complicated regex structures.


In the constructors of the Regex class, it will take in a string or a byte array as for generating a regex matcher. The received string or byte array will be stored and go through the `compile()` method of the Analyser class. The Analyser class will then use different parsing methods in the Parser class to parse the regular expression. Those parse methods will call each other recursively depending on the structure of the given string or byte array. If the input is too long or contains so many complicated or levelled structures, the depth of the recursion will be high. As each of the recursive calls will occupy part of the stack, the high depth of recursion will use up the stack quickly and result in a stack memory overflow problem.


This PR reduces the problem by adding an additional length limit as a private class variable. If the provided regex string or byte array is longer than the maximum length. The method will simply throw a ValueException.


We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated joni (https://github.com/google/oss-fuzz/pull/10680). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.
