### PR TITLE
fix: change Java target from 1.7 to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This aligns the Java Target with JRuby:

https://github.com/jruby/jruby/blob/42197f4bb6649be8e867329f669bfa4966287ecd/pom.xml#L109-L110