### PR TITLE
Fix multiplex backreferences near end of string in regexp match

### DIFF
--- a/src/org/joni/ByteCodeMachine.java
+++ b/src/org/joni/ByteCodeMachine.java
@@ -1442,7 +1442,7 @@ class ByteCodeMachine extends StackMachine {
             int pend = backrefEnd(mem);
 
             int n = pend - pstart;
-            if (s + n > range) {opFail(); return;}
+            if (s + n > range) continue;
 
             sprev = s;
             int swork = s;
@@ -1478,7 +1478,7 @@ class ByteCodeMachine extends StackMachine {
             int pend = backrefEnd(mem);
 
             int n = pend - pstart;
-            if (s + n > range) {opFail(); return;}
+            if (s + n > range) continue;
 
             sprev = s;
 


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/18631

See https://github.com/ruby/ruby/pull/5710